### PR TITLE
Fix site title color in dark mode

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,7 +1,7 @@
 :root {
   --background-color: #f4f1ec;
   --foreground-color: #000000;
-  --highlight-color: orangered;
+  --highlight-color: purple;
   --box-border-radius: 3px;
   --media-border-radius: 8px;
   --dot-size: 8px;
@@ -19,9 +19,30 @@
   --secondary-color: #999;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: #181a1b;
+    --foreground-color: #f4f1ec;
+    --border-color: rgba(255, 255, 255, 0.2);
+    --cell-background-color: #222;
+    --code-background-color: #282828;
+    --secondary-color: #bbb;
+  }
+
+  a.site-title:link,
+  a.site-title:visited {
+    color: #eee;
+  }
+
+  a.site-title:hover {
+    color: #fff;
+  }
+}
+
 body {
   background-color: var(--background-color);
   color: var(--foreground-color);
+  color-scheme: light dark;
   font-family:
     ui-sans-serif,
     system-ui,

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -72,7 +72,8 @@ const navs = (getEnv(import.meta.env, Astro, 'NAVS') || '')
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#f4f1ec" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f4f1ec" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#181a1b" />
     <link rel="alternate" type="application/rss+xml" title={`${RSS_PREFIX}${channel?.title}`} href={RSS_URL} />
     <style is:inline>
       @view-transition {


### PR DESCRIPTION
## Summary
- add dark color scheme variables
- enable OS-based theme switching
- keep highlight color purple
- fix site title color for dark mode

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH 172.20.0.3:8080)*

------
https://chatgpt.com/codex/tasks/task_b_683bfa6689b08323a64b2154a277cfa1